### PR TITLE
serialize redesign

### DIFF
--- a/src/shared/double_ratchet_utils.h
+++ b/src/shared/double_ratchet_utils.h
@@ -51,7 +51,7 @@ struct Header : public Serializable<Header> {
         serialize::serialize(n, result);
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }
@@ -96,7 +96,7 @@ struct Message : public Serializable<Message> {
         serialize::serialize(hmac, result);
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }

--- a/src/shared/request_response.cpp
+++ b/src/shared/request_response.cpp
@@ -7,41 +7,41 @@ uint32_t &MessageNumberGenerator::getNextNumber(uint32_t userId) {
     return messageNumbers[userId].lastSent;
 }
 
-std::vector<unsigned char> Request::Header::serialize() const {
-    std::vector<unsigned char> ret;
+serialize::structure& Request::Header::serialize(serialize::structure& result) const {
     const_cast<Header *>(this)->messageNumber = MessageNumberGenerator::getNextNumber(userId)++;
-    addNumeric(ret, static_cast<uint32_t >(type));
-    addNumeric(ret, messageNumber);
-    addNumeric(ret, userId);
-    return ret;
+    serialize::serialize(static_cast<uint32_t >(type), result);
+    serialize::serialize(messageNumber, result);
+    serialize::serialize(userId, result);
+    return result;
 }
 
-Request::Header Request::Header::deserialize(const std::vector<unsigned char> &data) {
+Request::Header Request::Header::deserialize(const serialize::structure &data, uint64_t& from) {
     Header ret;
-    uint64_t offset = 0;
-    uint32_t type;
-    offset += getNumeric(data, offset, type);
+    uint32_t type =
+            serialize::deserialize<uint32_t >(data, from);
     ret.type = static_cast<Type >(type);
-    offset += getNumeric(data, offset, ret.messageNumber);
-    getNumeric(data, offset, ret.userId);
+    ret.messageNumber =
+            serialize::deserialize<decltype(ret.messageNumber)>(data, from);
+    ret.userId =
+            serialize::deserialize<decltype(ret.userId)>(data, from);
     return ret;
 }
 
-Response::Header  Response::Header::deserialize(const std::vector<unsigned char> &data) {
+Response::Header  Response::Header::deserialize(const serialize::structure &data, uint64_t& from) {
     Header ret;
-    uint64_t offset = 0;
-    uint32_t type;
-    offset += getNumeric(data, offset, type);
+    uint32_t type =
+            serialize::deserialize<uint32_t >(data, from);
     ret.type = static_cast<Type >(type);
-    offset += getNumeric(data, offset, ret.messageNumber);
-    getNumeric(data, offset, ret.userId);
+    ret.messageNumber =
+            serialize::deserialize<decltype(ret.messageNumber)>(data, from);
+    ret.userId =
+            serialize::deserialize<decltype(ret.userId)>(data, from);
     return ret;
 }
 
-std::vector<unsigned char> Response::Header::serialize() const  {
-    std::vector<unsigned char> ret;
-    addNumeric(ret, static_cast<uint32_t >(type));
-    addNumeric(ret, messageNumber);
-    addNumeric(ret, userId);
-    return ret;
+serialize::structure& Response::Header::serialize(serialize::structure& result) const  {
+    serialize::serialize(static_cast<uint32_t >(type), result);
+    serialize::serialize(messageNumber, result);
+    serialize::serialize(userId, result);
+    return result;
 }

--- a/src/shared/request_response.h
+++ b/src/shared/request_response.h
@@ -42,7 +42,7 @@ struct Request {
         REMOVE, SEND, GET_ONLINE, FIND_USERS, KEY_BUNDLE_UPDATE, GET_RECEIVERS_BUNDLE
     };
 
-    struct Header : Serializable<Request::Header> {
+    struct Header : public Serializable<Request::Header> {
         Type type{};
         uint32_t messageNumber{};
         uint32_t userId{};
@@ -52,9 +52,17 @@ struct Request {
         Header(Type type, uint32_t messageNumber, uint32_t userId)
                 : type(type), messageNumber(messageNumber), userId(userId) {}
 
-        std::vector<unsigned char> serialize() const override;
+        serialize::structure& serialize(serialize::structure& result) const override;
+        serialize::structure serialize() const {
+            serialize::structure result;
+            return serialize(result);
+        }
 
-        static Request::Header deserialize(const std::vector<unsigned char> &data);
+        static Header deserialize(const serialize::structure &data, uint64_t& from);
+        static Header deserialize(const std::vector<unsigned char> &data) {
+            uint64_t from = 0;
+            return deserialize(data, from);
+        };
     };
 
     Header header;
@@ -82,7 +90,7 @@ struct Response {
         KEY_BUNDLE_UPDATED
     };
 
-    struct Header : Serializable<Response::Header> {
+    struct Header : public Serializable<Response::Header> {
         Type type{};
         uint32_t messageNumber{};
         uint32_t userId{};
@@ -92,9 +100,17 @@ struct Response {
         Header(Type type, uint32_t messageNumber, uint32_t userId)
                 : type(type), messageNumber(messageNumber), userId(userId) {}
 
-        std::vector<unsigned char> serialize() const override;
+        serialize::structure& serialize(serialize::structure& result) const override;
+        serialize::structure serialize() const {
+            serialize::structure result;
+            return serialize(result);
+        }
 
-        static Response::Header deserialize(const std::vector<unsigned char> &data);
+        static Header deserialize(const serialize::structure &data, uint64_t& from);
+        static Header deserialize(const std::vector<unsigned char> &data) {
+            uint64_t from = 0;
+            return deserialize(data, from);
+        };
     };
 
     Header header;

--- a/src/shared/request_response.h
+++ b/src/shared/request_response.h
@@ -53,7 +53,7 @@ struct Request {
                 : type(type), messageNumber(messageNumber), userId(userId) {}
 
         serialize::structure& serialize(serialize::structure& result) const override;
-        serialize::structure serialize() const {
+        serialize::structure serialize() const override {
             serialize::structure result;
             return serialize(result);
         }
@@ -101,7 +101,7 @@ struct Response {
                 : type(type), messageNumber(messageNumber), userId(userId) {}
 
         serialize::structure& serialize(serialize::structure& result) const override;
-        serialize::structure serialize() const {
+        serialize::structure serialize() const override {
             serialize::structure result;
             return serialize(result);
         }

--- a/src/shared/requests.h
+++ b/src/shared/requests.h
@@ -46,7 +46,7 @@ struct KeyBundle : Serializable<KeyBundle<Asymmetric> > {
         serialize::serialize(oneTimeKeys, result);
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }
@@ -89,7 +89,7 @@ struct AuthenticateRequest : public Serializable<AuthenticateRequest> {
         serialize::serialize(publicKey, result);
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }
@@ -128,7 +128,7 @@ struct CompleteAuthRequest : public Serializable<CompleteAuthRequest> {
 
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }
@@ -160,7 +160,7 @@ struct GenericRequest : public Serializable<AuthenticateRequest> {
         serialize::serialize(name, result);
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }
@@ -197,7 +197,7 @@ struct GetUsers : public Serializable<GetUsers> {
         serialize::serialize(query, result);
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }
@@ -232,7 +232,7 @@ struct SendData : public Serializable<SendData> {
         serialize::serialize(data, result);
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }
@@ -278,7 +278,7 @@ struct X3DHRequest : public Serializable<X3DHRequest<Asymmetric>> {
         serialize::serialize(AEADenrypted, result);
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }

--- a/src/shared/requests.h
+++ b/src/shared/requests.h
@@ -38,26 +38,38 @@ struct KeyBundle : Serializable<KeyBundle<Asymmetric> > {
         timestamp = lt->tm_year * 366 * 24 + lt->tm_yday * 24 + lt->tm_hour;
     }
 
-    std::vector<unsigned char> serialize() const override {
-        std::vector<unsigned char> result;
-        Serializable<KeyBundle<Asymmetric> >::addNumeric(result, timestamp);
-        Serializable<KeyBundle<Asymmetric> >::addContainer(result, identityKey);
-        Serializable<KeyBundle<Asymmetric> >::addContainer(result, preKey);
-        Serializable<KeyBundle<Asymmetric> >::addContainer(result, preKeySingiture);
-        Serializable<KeyBundle<Asymmetric> >::addNestedContainer(result, oneTimeKeys);
+    serialize::structure& serialize(serialize::structure& result) const override {
+        serialize::serialize(timestamp, result);
+        serialize::serialize(identityKey, result);
+        serialize::serialize(preKey, result);
+        serialize::serialize(preKeySingiture, result);
+        serialize::serialize(oneTimeKeys, result);
         return result;
+    }
+    serialize::structure serialize() const {
+        serialize::structure result;
+        return serialize(result);
     }
 
-    static KeyBundle deserialize(const std::vector<unsigned char> &data) {
+    static KeyBundle deserialize(const serialize::structure  &data, uint64_t& from) {
         KeyBundle result;
-        uint64_t offset = 0;
-        offset += Serializable<KeyBundle<Asymmetric> >::getNumeric(data, offset, result.timestamp);
-        offset += Serializable<KeyBundle<Asymmetric> >::getContainer(data, offset, result.identityKey);
-        offset += Serializable<KeyBundle<Asymmetric> >::getContainer(data, offset, result.preKey);
-        offset += Serializable<KeyBundle<Asymmetric> >::getContainer(data, offset, result.preKeySingiture);
-        offset += Serializable<KeyBundle<Asymmetric> >::getNestedContainer(data, offset, result.oneTimeKeys);
+        result.timestamp =
+                serialize::deserialize<decltype(result.timestamp)>(data, from);
+        result.identityKey =
+                serialize::deserialize<decltype(result.identityKey)>(data, from);
+        result.preKey =
+                serialize::deserialize<decltype(result.preKey)>(data, from);
+        result.preKeySingiture =
+                serialize::deserialize<decltype(result.preKeySingiture)>(data, from);
+        result.oneTimeKeys =
+                serialize::deserialize<decltype(result.oneTimeKeys)>(data, from);
         return result;
     }
+    static KeyBundle deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
+    }
+
 };
 
 
@@ -71,25 +83,30 @@ struct AuthenticateRequest : public Serializable<AuthenticateRequest> {
     AuthenticateRequest(std::string name, std::vector<unsigned char> publicKey)
             : name(std::move(name)), publicKey(std::move(publicKey)) {}
 
-    std::vector<unsigned char> serialize() const override {
-        std::vector<unsigned char> result;
-        Serializable::addContainer<std::string>(result, name);
-        Serializable::addContainer<std::string>(result, sessionKey);
-        Serializable::addContainer<std::vector<unsigned char>>(result, publicKey);
-
+    serialize::structure& serialize(serialize::structure& result) const override {
+        serialize::serialize(name, result);
+        serialize::serialize(sessionKey, result);
+        serialize::serialize(publicKey, result);
         return result;
     }
+    serialize::structure serialize() const {
+        serialize::structure result;
+        return serialize(result);
+    }
 
-    static AuthenticateRequest deserialize(const std::vector<unsigned char> &data) {
+    static AuthenticateRequest deserialize(const serialize::structure  &data, uint64_t& from) {
         AuthenticateRequest result;
-        uint64_t position = 0;
-        position += Serializable::getContainer<std::string>(data, position,
-                                                            result.name);
-        position += Serializable::getContainer<std::string>(data, position,
-                                                            result.sessionKey);
-        Serializable::getContainer<std::vector<unsigned char>>(data, position,
-                                                               result.publicKey);
+        result.name =
+                serialize::deserialize<decltype(result.name)>(data, from);
+        result.sessionKey =
+                serialize::deserialize<decltype(result.sessionKey)>(data, from);
+        result.publicKey =
+                serialize::deserialize<decltype(result.publicKey)>(data, from);
         return result;
+    }
+    static AuthenticateRequest deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
     }
 };
 
@@ -105,23 +122,29 @@ struct CompleteAuthRequest : public Serializable<CompleteAuthRequest> {
     CompleteAuthRequest(std::vector<unsigned char> secret, std::string name)
             : secret(std::move(secret)), name(std::move(name)) {}
 
-    std::vector<unsigned char> serialize() const override {
-        std::vector<unsigned char> result;
-        Serializable::addContainer<std::vector<unsigned char>>(result, secret);
-        Serializable::addContainer<std::string>(result, name);
+    serialize::structure& serialize(serialize::structure& result) const override {
+        serialize::serialize(secret, result);
+        serialize::serialize(name, result);
 
         return result;
     }
+    serialize::structure serialize() const {
+        serialize::structure result;
+        return serialize(result);
+    }
 
-    static CompleteAuthRequest deserialize(const std::vector<unsigned char> &data) {
+    static CompleteAuthRequest deserialize(const serialize::structure &data, uint64_t& from) {
         CompleteAuthRequest result;
-        uint64_t position = 0;
-        position += Serializable::getContainer<std::vector<unsigned char>>(
-                data, position, result.secret);
-        position += Serializable::getContainer<std::string>(data, position,
-                                                            result.name);
+        result.secret = serialize::deserialize<std::vector<unsigned char>>(data, from);
+        result.name = serialize::deserialize<std::string>(data, from);
         return result;
     }
+
+    static CompleteAuthRequest deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
+    }
+
 };
 
 struct GenericRequest : public Serializable<AuthenticateRequest> {
@@ -132,21 +155,28 @@ struct GenericRequest : public Serializable<AuthenticateRequest> {
 
     GenericRequest(uint32_t id, std::string name) : id(id), name(std::move(name)) {}
 
-    std::vector<unsigned char> serialize() const override {
-        std::vector<unsigned char> result;
-        Serializable::addNumeric<uint32_t>(result, id);
-        Serializable::addContainer<std::string>(result, name);
+    serialize::structure& serialize(serialize::structure& result) const override {
+        serialize::serialize(id, result);
+        serialize::serialize(name, result);
+        return result;
+    }
+    serialize::structure serialize() const {
+        serialize::structure result;
+        return serialize(result);
+    }
+
+    static GenericRequest deserialize(const serialize::structure &data, uint64_t& from) {
+        GenericRequest result;
+        result.id = serialize::deserialize<uint32_t>(data, from);
+        result.name = serialize::deserialize<std::string>(data, from);
         return result;
     }
 
-    static GenericRequest deserialize(
-            const std::vector<unsigned char> &data) {
-        GenericRequest result;
-        uint64_t position = 0;
-        position += Serializable::getNumeric<uint32_t>(data, position, result.id);
-        position += Serializable::getContainer<std::string>(data, position, result.name);
-        return result;
+    static GenericRequest deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
     }
+
 };
 
 struct GetUsers : public Serializable<GetUsers> {
@@ -161,21 +191,28 @@ struct GetUsers : public Serializable<GetUsers> {
             name(std::move(name)),
             query(std::move(query)) {}
 
-    std::vector<unsigned char> serialize() const override {
-        std::vector<unsigned char> result;
-        Serializable::addNumeric<uint32_t>(result, id);
-        Serializable::addContainer<std::string>(result, name);
-        Serializable::addContainer<std::string>(result, query);
+    serialize::structure& serialize(serialize::structure& result) const override {
+        serialize::serialize(id, result);
+        serialize::serialize(name, result);
+        serialize::serialize(query, result);
         return result;
     }
+    serialize::structure serialize() const {
+        serialize::structure result;
+        return serialize(result);
+    }
 
-    static GetUsers deserialize(const std::vector<unsigned char> &data) {
+    static GetUsers deserialize(const serialize::structure &data, uint64_t& from) {
         GetUsers result;
-        uint64_t position = 0;
-        position += Serializable::getNumeric<uint32_t>(data, position, result.id);
-        position += Serializable::getContainer<std::string>(data, position, result.name);
-        position += Serializable::getContainer<std::string>(data, position, result.query);
+
+        result.id = serialize::deserialize<uint32_t>(data, from);
+        result.name = serialize::deserialize<std::string>(data, from);
+        result.query = serialize::deserialize<std::string>(data, from);
         return result;
+    }
+    static GetUsers deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
     }
 };
 
@@ -189,21 +226,29 @@ struct SendData : public Serializable<SendData> {
     SendData(std::string date, std::string from, std::vector<unsigned char> data) :
             date(std::move(date)), from(std::move(from)), data(std::move(data)) {}
 
-    std::vector<unsigned char> serialize() const override {
-        std::vector<unsigned char> result;
-        Serializable::addContainer<std::string>(result, date);
-        Serializable::addContainer<std::string>(result, from);
-        Serializable::addContainer<std::vector<unsigned char>>(result, data);
+    serialize::structure& serialize(serialize::structure& result) const override {
+        serialize::serialize(date, result);
+        serialize::serialize(from, result);
+        serialize::serialize(data, result);
+        return result;
+    }
+    serialize::structure serialize() const {
+        serialize::structure result;
+        return serialize(result);
+    }
+
+    static SendData deserialize(const serialize::structure &data, uint64_t& from) {
+        SendData result;
+        result.date = serialize::deserialize<std::string>(data, from);
+        result.from = serialize::deserialize<std::string>(data, from);
+        result.data = serialize::deserialize<decltype(result.data)>(data, from);
+
         return result;
     }
 
-    static SendData deserialize(const std::vector<unsigned char> &data) {
-        SendData result;
-        uint64_t position = 0;
-        position += Serializable::getContainer<std::string>(data, position, result.date);
-        position += Serializable::getContainer<std::string>(data, position, result.from);
-        position += Serializable::getContainer<std::vector<unsigned char>>(data, position, result.data);
-        return result;
+    static SendData deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
     }
 };
 
@@ -224,27 +269,39 @@ struct X3DHRequest : public Serializable<X3DHRequest<Asymmetric>> {
 
     X3DHRequest() = default;
 
-    std::vector<unsigned char> serialize() const override {
-        std::vector<unsigned char> result;
-        Serializable<X3DHRequest<Asymmetric> >::addNumeric(result, timestamp);
-        Serializable<X3DHRequest<Asymmetric> >::addContainer(result, senderIdPubKey);
-        Serializable<X3DHRequest<Asymmetric> >::addContainer(result, senderEphermalPubKey);
-        Serializable<X3DHRequest<Asymmetric> >::addNumeric(result, opKeyUsed);
-        Serializable<X3DHRequest<Asymmetric> >::addNumeric(result, opKeyId);
-        Serializable<X3DHRequest<Asymmetric> >::addContainer(result, AEADenrypted);
+    serialize::structure& serialize(serialize::structure& result) const override {
+        serialize::serialize(timestamp, result);
+        serialize::serialize(senderIdPubKey, result);
+        serialize::serialize(senderEphermalPubKey, result);
+        serialize::serialize(opKeyUsed, result);
+        serialize::serialize(opKeyId, result);
+        serialize::serialize(AEADenrypted, result);
         return result;
     }
+    serialize::structure serialize() const {
+        serialize::structure result;
+        return serialize(result);
+    }
 
-    static X3DHRequest deserialize(const std::vector<unsigned char> &data) {
+    static X3DHRequest deserialize(const serialize::structure &data, uint64_t& from) {
         X3DHRequest result;
-        uint64_t offset = 0;
-        offset += Serializable<X3DHRequest<Asymmetric> >::getNumeric(data, offset, result.timestamp);
-        offset += Serializable<X3DHRequest<Asymmetric> >::getContainer(data, offset, result.senderIdPubKey);
-        offset += Serializable<X3DHRequest<Asymmetric> >::getContainer(data, offset, result.senderEphermalPubKey);
-        offset += Serializable<X3DHRequest<Asymmetric> >::getNumeric(data, offset, result.opKeyUsed);
-        offset += Serializable<X3DHRequest<Asymmetric> >::getNumeric(data, offset, result.opKeyId);
-        offset += Serializable<X3DHRequest<Asymmetric> >::getContainer(data, offset, result.AEADenrypted);
+        result.timestamp =
+                serialize::deserialize<decltype(result.timestamp)>(data, from);
+        result.senderIdPubKey =
+                serialize::deserialize<decltype(result.senderIdPubKey)>(data, from);
+        result.senderEphermalPubKey =
+                serialize::deserialize<decltype(result.senderEphermalPubKey)>(data, from);
+        result.opKeyUsed =
+                serialize::deserialize<decltype(result.opKeyUsed)>(data, from);
+        result.opKeyId =
+                serialize::deserialize<decltype(result.opKeyId)>(data, from);
+        result.AEADenrypted =
+                serialize::deserialize<decltype(result.AEADenrypted)>(data, from);
         return result;
+    }
+    static X3DHRequest deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
     }
 };
 

--- a/src/shared/responses.h
+++ b/src/shared/responses.h
@@ -28,19 +28,27 @@ struct UserListReponse : public Serializable<UserListReponse> {
     UserListReponse(std::vector<std::string> users, std::vector<uint32_t> ids) :
             ids(std::move(ids)), online(std::move(users)) {}
 
-    std::vector<unsigned char> serialize() const override {
-        std::vector<unsigned char> result;
-        Serializable::addContainer<std::vector<uint32_t >>(result, ids);
-        Serializable::addNestedContainer<std::vector<std::string>, std::string>(result, online);
+    serialize::structure& serialize(serialize::structure& result) const override {
+        serialize::serialize(ids, result);
+        serialize::serialize(online, result);
         return result;
     }
+    serialize::structure serialize() const {
+        serialize::structure result;
+        return serialize(result);
+    }
 
-    static UserListReponse deserialize(const std::vector<unsigned char> &data) {
+    static UserListReponse deserialize(const serialize::structure  &data, uint64_t& from) {
         UserListReponse result;
-        uint64_t position = 0;
-        position += Serializable::getContainer<std::vector<uint32_t >>(data, position, result.ids);
-        position += Serializable::getNestedContainer<std::vector<std::string>, std::string>(data, position, result.online);
+        result.ids =
+                serialize::deserialize<decltype(result.ids)>(data, from);
+        result.online =
+                serialize::deserialize<decltype(result.online)>(data, from);
         return result;
+    }
+    static UserListReponse deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
     }
 };
 

--- a/src/shared/responses.h
+++ b/src/shared/responses.h
@@ -33,7 +33,7 @@ struct UserListReponse : public Serializable<UserListReponse> {
         serialize::serialize(online, result);
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }

--- a/src/shared/serializable.h
+++ b/src/shared/serializable.h
@@ -19,247 +19,120 @@
 #include <cassert>
 
 namespace helloworld {
-    namespace detail {
-        template<typename T, typename _ = void>
-        struct is_container : std::false_type {};
+    namespace serialize {
+        using structure = std::vector<unsigned char>;
+    }
+    namespace detail
+    {
+        template<typename T, typename = void>
+        struct is_container : public std::false_type {};
 
-        template<typename... Ts>
-        struct is_container_helper {};
-
+        template<typename ... Args>
+        struct container_helper {};
 
         template<typename T>
         struct is_container<
                 T,
-                std::conditional_t<
-                        false,
-                        is_container_helper<
-                                decltype(std::end(std::declval<T>())),
-                                decltype(std::begin(std::declval<T>()))
+                std::conditional_t<false,
+                        container_helper<
+                                decltype(std::begin(std::declval<T>())),
+                                decltype(std::end(std::declval<T>()))
                         >,
                         void
                 >
         > : public std::true_type {};
 
-        template<typename T, typename = void>
-        struct has_static_storage : std::true_type {};
+    } // detail
 
-        template<typename T>
-        struct has_static_storage<
-                T,
-                std::conditional_t<
-                        false,
-                        is_container_helper<
-                                decltype(std::declval<T>().push_back(*std::declval<T>().begin()))
-                        >,
-                        void
-                >
-        > : public std::false_type {};
-
-        template<class T, size_t N>
-        uint64_t size(T (&)[N]) { return N; }
-
-        template<class T>
-        auto size(const T& container) -> typename std::enable_if< is_container<T>::value, uint64_t >::type { return container.size(); }
-    }
-template <typename Obj>
-struct Serializable {
-    virtual ~Serializable() = default;
-
-    /**
-     * Serialize Obj into unsigned char vector
-     *
-     * @return std::vector<unsigned int> serialized object
-     */
-    virtual std::vector<unsigned char> serialize() const = 0;
-
-    /**
-     * Obj has to implement its static getter
-     * named deserialize with const std::vector<unsigned char>& as param
-     *
-     * @param data data to parse
-     * @return Obj deserialized object
-     */
-    static Obj deserialize(const std::vector<unsigned char>& data) {
-        return Obj::deserialize(data);
+    template<typename Obj>
+    struct Serializable {
+        virtual serialize::structure& serialize(serialize::structure& result) const = 0;
+        virtual serialize::structure serialize() const = 0;
+        static Obj deserialize(const serialize::structure& data, uint64_t& from) {
+            return Obj::deserialize(data, from);
+        }
+        static Obj deserialize(const serialize::structure& data) {
+            uint64_t from = 0;
+            return Obj::deserialize(data, from);
+        }
+        virtual ~Serializable() = default;
     };
 
-    /**
-     * Save numeric type value into output vector
-     *
-     * @tparam num numeric integral type
-     * @param output output buffer to put data to
-     * @param input data to process
-     */
-    template <typename num>
-    static void addNumeric(std::vector<unsigned char>& output, const num& input) {
-        int n = sizeof(input);
-        for(int y = 0; n --> 0; y++)
-            output.push_back((input >> (n*8)) & 0xFF);
-    }
+    namespace serialize {
 
-    /**
-     * Inverse for addNumeric
-     *for (uint64_t i = 0; i < len; i++)
-     * @tparam num numeric integral type
-     * @param input input data buffer
-     * @param from index in buffer where to start reading
-     * @param output reference to value to fill
-     * @return num of values read in bytes - equals to /position in / length of/ buffer
-     */
-    template <typename num>
-    static uint64_t getNumeric(const std::vector<unsigned char>& input, uint64_t from, num& output) {
-        output = 0;
-        int n = sizeof(output);
-        for(int y = 0; n --> 0; y++)
-            output += (input[from + y] << (n*8));
-        return sizeof(output);
-    }
+        template<typename T>
+        struct is_serializable : std::is_base_of<Serializable<T>, T> {
+        };
 
-    /**
-     * Save container type value into output vector
-     * the input value must be of a primitive type
-     * 
-     * !! this method works only for scalar inner value types
-     * !! ignores endianity
-     *
-     * @tparam container container type supporting push_back() method, operator[] and size()
-     * @param output output buffer
-     * @param input input data container
-     */
-    template<typename container>
-    static auto addContainer(std::vector<unsigned char>& output, const container& input) ->
-    typename std::enable_if< detail::is_container<container>::value, void >::type
-    {
 
-        using value_type = std::remove_cv_t<std::remove_reference_t<decltype(*std::begin(input))> >;
+        template<typename T>
+        auto serialize(const T &obj,
+                       serialize::structure &result) -> typename std::enable_if<is_serializable<T>::value, serialize::structure>::type {
+            return obj.serialize(result);
+        }
 
-        union {
-            unsigned char bytes[sizeof(value_type)];
-            value_type value;
-        } data;
-
-        addNumeric(output, detail::size(input));
-        auto __begin = std::begin(input);
-        auto __end = std::end(input);
-        for (; __begin != __end; ++__begin) {
-            data.value = *__begin;
-            for (unsigned char c : data.bytes) {
-                output.push_back(c);
+        template<typename T>
+        auto serialize(const T &obj, serialize::structure &result)
+        -> typename std::enable_if<std::is_scalar<T>::value, serialize::structure>::type {
+            union {
+                unsigned char bytes[sizeof(T)];
+                T value;
+            } helper;
+            helper.value = obj;
+            for (auto i : helper.bytes) {
+                result.push_back(i);
             }
+            return result;
         }
-    }
-    /**
-     * Inverse of addContainer
-     *
-     * @tparam container container type supporting push_back() method, operator[] and size()
-     * @param input data buffer
-     * @param from index in buffer where to start reading
-     * @param output output container
-     * @return num of values read in bytes
-     */
-    template<typename container>
-    static auto getContainer(const std::vector<unsigned char>& input, uint64_t from, container& output)
-    -> typename std::enable_if<detail::is_container<container>::value && !detail::has_static_storage<container>::value, uint64_t >::type {
 
-        using value_type = std::remove_cv_t<std::remove_reference_t<decltype(*std::begin(output))> >;
 
-        union {
-            unsigned char bytes[sizeof(value_type)];
-            value_type value;
-        } data;
+        template<typename T>
+        auto serialize(const T &obj, serialize::structure &result)
+        -> typename std::enable_if<detail::is_container<T>::value, serialize::structure>::type {
+            uint64_t size = obj.size();
+            serialize<uint64_t>(size, result);
 
-        uint64_t len = 0;
-        uint64_t metadata = getNumeric(input, from, len);
-
-        for (uint64_t i = 0; i < len; ++i) {
-            for (uint64_t ii = 0; ii < sizeof(value_type); ii++) {
-                data.bytes[ii] = input[from + i * sizeof(value_type) + metadata + ii];
+            for (const auto &i : obj) {
+                serialize(i, result);
             }
-            output.push_back(data.value);
+            return result;
         }
 
-        return len * sizeof(value_type) + metadata;
-    }
-
-    /**
-    * Inverse of addContainer for container not supporting pushback
-    *
-    * @tparam container container type supporting push_back() method, operator[] and size()
-    * @param input data buffer
-    * @param from index in buffer where to start reading
-    * @param output output container
-    * @return num of values read in bytes
-    */
-    template<typename container>
-    static auto getContainer(const std::vector<unsigned char>& input, uint64_t from, container& output)
-    -> typename std::enable_if<detail::is_container<container>::value && detail::has_static_storage<container>::value, uint64_t >::type {
-
-        using value_type = std::remove_cv_t<std::remove_reference_t<decltype(*std::begin(output))> >;
-
-        union {
-            unsigned char bytes[sizeof(value_type)];
-            value_type value;
-        } data;
-
-        uint64_t len = 0;
-        uint64_t metadata = getNumeric(input, from, len);
-
-        assert(len == detail::size(output));
-
-        auto outputBegin = output.begin;
-
-        for (uint64_t i = 0; i < len; ++i, ++outputBegin) {
-            for (uint64_t ii = 0; ii < sizeof(value_type); ii++) {
-                data.bytes[ii] = input[from + i * sizeof(value_type) + metadata + ii];
+        template<typename T>
+        auto
+        deserialize(const std::vector<unsigned char> &input, uint64_t &from)
+        -> typename std::enable_if<std::is_scalar<T>::value, T>::type {
+            union {
+                unsigned char bytes[sizeof(T)];
+                T value;
+            } helper;
+            for (auto i = from; from < i + sizeof(T); ++from) {
+                helper.bytes[from - i] = input[from];
             }
-            *outputBegin = data.value;
+            return helper.value;
         }
 
-        return len * sizeof(value_type) + metadata;
-    }
-    /**
-     * Save nested containers into buffer output, the inner container must be
-     * applicable to getContainer() method
-     * 
-     * !! this method works only for container that
-     *    contains values serializable with addContainer() method
-     *
-     * @tparam container container type supporting push_back() method, operator[] and size()
-     * @param output output buffer
-     * @param input input data container
-     */
-    template <typename container, typename inner = typename std::remove_cv_t<std::remove_reference_t<decltype(*std::begin(std::declval<container>()))> > >
-    static void addNestedContainer(std::vector<unsigned char>& output, const container& input) {
-
-        addNumeric(output, input.size());
-        for (uint64_t i = 0; i < input.size(); i++) {
-            addContainer(output, input[i]);
+        template<typename T>
+        auto
+        deserialize(const std::vector<unsigned char> &input, uint64_t &from)
+        -> typename std::enable_if<is_serializable<T>::value, T>::type {
+            return Serializable<T>::deserialize(input, from);
         }
-    }
 
-    /**
-     * Inverse of addNestedContainer
-     *
-     * @tparam container container type supporting push_back() method, operator[] and size()
-     * @param input data buffer
-     * @param from index in buffer where to start reading
-     * @param output output container
-     * @return num of values read in bytes
-     */
-    template <typename container, typename inner = typename std::remove_cv_t<std::remove_reference_t<decltype(*std::begin(std::declval<container>()))> > >
-    static uint64_t getNestedContainer(const std::vector<unsigned char>& input, uint64_t from, container& output) {
-        uint64_t len = 0;
-        uint64_t metadata = getNumeric(input, from, len);
-
-        for (uint64_t i = 0; i < len; i++) {
-            inner tempContainer;
-            metadata += getContainer(input, metadata + from, tempContainer);
-            output.push_back(tempContainer);
+        template<typename T, typename value_type = typename T::value_type>
+        auto
+        deserialize(const std::vector<unsigned char> &input, uint64_t &from)
+        -> typename std::enable_if<detail::is_container<T>::value, T>::type {
+            T result;
+            uint64_t size = deserialize<uint64_t>(input, from);
+            for (uint64_t i = 0; i < size; ++i) {
+                value_type tmp = deserialize<value_type>(input, from);
+                result.push_back(std::move(tmp));
+            }
+            return result;
         }
-        return len + metadata;
-    }
-};
 
+    }
 }
 
 #endif //HELLOWORLD_SHARED_SERIALIZABLE_H_

--- a/src/shared/serializable_error.h
+++ b/src/shared/serializable_error.h
@@ -28,18 +28,24 @@ struct Error : public std::exception, public Serializable<Error> {
 
     const char *what() const noexcept override { return message.c_str(); }
 
-    std::vector<unsigned char> serialize() const override {
-        std::vector<unsigned char> result;
-        Serializable::addContainer<std::string>(result, message);
+    serialize::structure& serialize(serialize::structure& result) const override {
+        serialize::serialize(message, result);
         return result;
     }
+    serialize::structure serialize() const {
+        serialize::structure result;
+        return serialize(result);
+    }
 
-    static Error deserialize(const std::vector<unsigned char> &data) {
+    static Error deserialize(const serialize::structure  &data, uint64_t& from) {
         Error result;
-        uint64_t position = 0;
-        position += Serializable::getContainer<std::string>(data, position,
-                                                            result.message);
+        result.message =
+                serialize::deserialize<decltype(result.message)>(data, from);
         return result;
+    }
+    static Error deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
     }
 };
 

--- a/src/shared/serializable_error.h
+++ b/src/shared/serializable_error.h
@@ -32,7 +32,7 @@ struct Error : public std::exception, public Serializable<Error> {
         serialize::serialize(message, result);
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }

--- a/src/shared/user_data.h
+++ b/src/shared/user_data.h
@@ -41,7 +41,7 @@ struct UserData : public Serializable<UserData> {
 
         return result;
     }
-    serialize::structure serialize() const {
+    serialize::structure serialize() const override {
         serialize::structure result;
         return serialize(result);
     }

--- a/src/shared/user_data.h
+++ b/src/shared/user_data.h
@@ -33,23 +33,34 @@ struct UserData : public Serializable<UserData> {
              sessionKey(std::move(sessionKey)),
              publicKey(std::move(publicKey)) {}
 
-    std::vector<unsigned char> serialize() const override {
-        std::vector<unsigned char> result;
-        Serializable::addNumeric<uint32_t>(result, id);
-        Serializable::addContainer<std::string>(result, name);
-        Serializable::addContainer<std::string>(result, sessionKey);
-        Serializable::addContainer<std::vector<unsigned char>>(result, publicKey);
+    serialize::structure& serialize(serialize::structure& result) const override {
+        serialize::serialize(id, result);
+        serialize::serialize(name, result);
+        serialize::serialize(sessionKey, result);
+        serialize::serialize(publicKey, result);
+
         return result;
     }
+    serialize::structure serialize() const {
+        serialize::structure result;
+        return serialize(result);
+    }
 
-    static UserData deserialize(const std::vector<unsigned char>& data) {
+    static UserData deserialize(const serialize::structure  &data, uint64_t& from) {
         UserData userData;
-        uint64_t position = 0;
-        position += Serializable::getNumeric<uint32_t>(data, 0, userData.id);
-        position += Serializable::getContainer<std::string>(data, position, userData.name);
-        position += Serializable::getContainer<std::string>(data, position, userData.sessionKey);
-        Serializable::getContainer<std::vector<unsigned char>>(data, position, userData.publicKey);
+        userData.id =
+                serialize::deserialize<decltype(userData.id)>(data, from);
+        userData.name =
+                serialize::deserialize<decltype(userData.name)>(data, from);
+        userData.sessionKey =
+                serialize::deserialize<decltype(userData.sessionKey)>(data, from);
+        userData.publicKey =
+                serialize::deserialize<decltype(userData.publicKey)>(data, from);
         return userData;
+    }
+    static UserData deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
     }
 };
 

--- a/test/shared/test_serialize.cpp
+++ b/test/shared/test_serialize.cpp
@@ -6,54 +6,200 @@
 
 using namespace helloworld;
 
-TEST_CASE("Serialization and deserialization simple class") {
-    UserData data { 6513246, "Honza", "2b7e151628aed2a6abf7158809cf4f3c", std::vector<unsigned char>(59, 65) };
+#include <stdint.h>
+#include <limits.h>
 
-    std::vector<unsigned char> ser = data.serialize();
-
-    UserData result = UserData::deserialize(ser);
-    CHECK(data.id == result.id);
-    CHECK(data.name == result.name);
-    CHECK(data.sessionKey == result.sessionKey);
-    CHECK(data.publicKey == result.publicKey);
-}
-
-struct Nested : public Serializable<Nested> {
-    std::vector<std::string> container;
-
-    std::vector<unsigned char> serialize() const override {
-        std::vector<unsigned char> result;
-        Serializable::addNestedContainer<std::vector<std::string>, std::string>(result, container);
+struct X : Serializable<X> {
+    serialize::structure& serialize(serialize::structure& result) const override {
+        result.push_back(0);
         return result;
     }
+    static X deserialize(const std::vector<unsigned char>& data, uint64_t& from) {
+        ++from;
+        return {};
+    }
+    friend bool operator==(const X& a, const X& b) {
+        return true;
+    }
+};
 
-    static Nested deserialize(const std::vector<unsigned char> &data) {
-        Nested userData;
-        Serializable::getNestedContainer<std::vector<std::string>, std::string>(data, 0, userData.container);
-        return userData;
+template<typename T>
+std::vector<T>& operator+=(std::vector<T>& one, const std::vector<T>& two) {
+    std::copy(two.begin(), two.end(), std::back_inserter(one));
+    return one;
+}
+
+struct Y : Serializable<Y> {
+    std::string s;
+    int i;
+    std::vector<char> v;
+
+    Y(std::string s = "", int i = 0,std::vector<char> v = {})
+            : s(s)
+            , i(i)
+            , v(v) {}
+    serialize::structure& serialize(serialize::structure& result) const override {
+
+        serialize::serialize(s, result);
+        serialize::serialize(i, result);
+        serialize::serialize(v, result);
+        return result;
+    }
+    static Y deserialize(const std::vector<unsigned char>& data, uint64_t& from) {
+        Y res;
+        res.s = serialize::deserialize<decltype(s)>(data, from);
+        res.i = serialize::deserialize<decltype(i)>(data, from);
+        res.v = serialize::deserialize<decltype(v)>(data, from);
+        return res;
+    }
+    friend bool operator==(const Y& a, const Y& b) {
+        return a.i == b.i && a.s == b.s && std::equal(a.v.begin(), a.v.end(), b.v.begin(), b.v.end());
     }
 };
 
 
-TEST_CASE("Serialize nested containers") {
+template<typename T>
+using equality = bool(*)(const T&, const T&);
 
-    Nested nested;
-    nested.container.emplace_back("Msdkjfbh");
-    nested.container.emplace_back("Another long data with so many cgaracters, yet the serialization does not fail us.");
-    nested.container.emplace_back("");
-    nested.container.emplace_back("alwietkvuhn\t\b alwkerha w kle\n\nurah w   "
-                                  " lei ufhawlefukha lsemig \tuah welkshegu\r\r\n\r\nawekeuanlsdkgusd");
+template<typename T>
+bool eq(const T& a, const T& b) {
+    return a == b;
+}
 
-    std::vector<unsigned char> data = nested.serialize();
-
-    Nested result = Nested::deserialize(data);
-
-    CHECK(result.container[0] == "Msdkjfbh");
-    CHECK(result.container[1] == "Another long data with so many cgaracters, yet the serialization does not fail us.");
-    CHECK(result.container[2] == "");
-    CHECK(result.container[3] == "alwietkvuhn\t\b alwkerha w kle\n\nurah w   "
-                                 " lei ufhawlefukha lsemig \tuah welkshegu\r\r\n\r\nawekeuanlsdkgusd");
+template<typename T>
+bool vec_eq(const std::vector<T>& a, const std::vector<T>& b) {
+    return std::equal(a.begin(), a.end(), b.begin(), b.end());
 }
 
 
+template<typename T, equality<T> eq = eq>
+struct test {
+    int testnum{0};
+    void run(const T& in) {
+        ++testnum;
+        SECTION(typeid(in).name(), std::to_string(testnum)) {
+            serialize::structure serialized;
+            serialize::serialize(in, serialized);
+            uint64_t from = 0;
+            T deserialized = serialize::deserialize<T>(serialized, from);
+            CHECK(from == serialized.size());
+            CHECK(eq(in, deserialized));
+        }
+    }
+};
 
+TEST_CASE("numberic types") {
+    SECTION("char") {
+        test<char> testint;
+        testint.run(0);
+        testint.run(CHAR_MAX);
+        testint.run(CHAR_MIN);
+    }
+    SECTION("ints") {
+        test<int> testint;
+        testint.run(0);
+        testint.run(INT_MAX);
+        testint.run(INT_MIN);
+    }
+    SECTION("int 64") {
+        test<int64_t> testint;
+        testint.run(0l);
+        testint.run(INT64_MAX);
+        testint.run(INT64_MIN);
+    }
+    SECTION("size_t") {
+        test<size_t> testint;
+        testint.run(0l);
+        testint.run(SIZE_MAX);
+    }
+    SECTION("ssize_t") {
+        test<ssize_t> testint;
+        testint.run(0l);
+        testint.run(SSIZE_MAX);
+        testint.run(LONG_MIN);
+    }
+}
+
+TEST_CASE("User defined types") {
+    SECTION("very simple") {
+        test<X> t;
+        t.run({});
+    }
+    SECTION("more complex") {
+        test<Y> t;
+
+        Y t1{};
+        Y t2{std::string("pizze"), 0, std::vector<char>{}};
+
+        Y t3{std::string("Cheesecake jelly-o candy apple pie. Muffin soufflé sesame snaps. Candy jelly beans jelly beans. Candy cake cupcake apple pie halvah gummies sesame snaps gummi bears."
+                         "Dessert liquorice lemon drops fruitcake jelly-o dessert gummies. Cake bear claw muffin "), -100, std::vector<char>{1,2,3}};
+        t.run(t1);
+        t.run(t2);
+        t.run(t3);
+    }
+}
+
+
+TEST_CASE("vector of objects") {
+
+
+    SECTION("strings") {
+
+        test<std::vector<std::string>, vec_eq<std::string>> test;
+
+
+        std::vector<std::string> t1{};
+        std::vector<std::string> t2{"one"};
+        std::vector<std::string> t3{"ahoj", "kamo", "ako", "sa", "mas"};
+
+        test.run(t1);
+        test.run(t2);
+        test.run(t3);
+    }
+    SECTION("user defined") {
+
+        test<std::vector<X>, vec_eq<X>> test;
+
+
+        std::vector<X> t1{};
+        std::vector<X> t2{{}};
+        std::vector<X> t3{{}, {}, {}, {}, {}};
+
+        test.run(t1);
+        test.run(t2);
+        test.run(t3);
+    }
+
+}
+
+template<typename T, typename = typename T::value_type>
+bool operator==(const T& a, const T& b) {
+    return std::equal(a.begin(), a.end(), b.begin(), b.end());
+}
+
+TEST_CASE("nested containers") {
+    SECTION("simple") {
+        using tested_type = std::vector<std::vector<char> >;
+        test<tested_type> t;
+
+        tested_type t0 = {};
+        tested_type t1 = {{'a'}, {'a', 'b', 'c'}, {}};
+        tested_type t2 = {{'a', 'b', 'c', 'd', 'e', 'f'}};
+
+        t.run(t0);
+        t.run(t1);
+        t.run(t2);
+    }
+    SECTION("totaly insane") {
+        using tested_type = std::vector<std::vector<std::vector<std::string>>>;
+        test<tested_type> t;
+
+        tested_type t0 = {};
+        tested_type t1 = {{{"why"}}};
+        tested_type t2 = {{{"why"}, {"would", "you"}}, {{"even", "do"}}, {{"this"}}};
+
+        t.run(t0);
+        t.run(t1);
+        t.run(t2);
+    }
+}

--- a/test/shared/test_serialize.cpp
+++ b/test/shared/test_serialize.cpp
@@ -14,9 +14,17 @@ struct X : Serializable<X> {
         result.push_back(0);
         return result;
     }
+    serialize::structure serialize() const override {
+        serialize::structure result;
+        return serialize(result);
+    }
     static X deserialize(const std::vector<unsigned char>& data, uint64_t& from) {
         ++from;
         return {};
+    }
+    static X deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
     }
     friend bool operator==(const X& a, const X& b) {
         return true;
@@ -45,12 +53,22 @@ struct Y : Serializable<Y> {
         serialize::serialize(v, result);
         return result;
     }
+    serialize::structure serialize() const override {
+        serialize::structure result;
+        return serialize(result);
+    }
+
+
     static Y deserialize(const std::vector<unsigned char>& data, uint64_t& from) {
         Y res;
         res.s = serialize::deserialize<decltype(s)>(data, from);
         res.i = serialize::deserialize<decltype(i)>(data, from);
         res.v = serialize::deserialize<decltype(v)>(data, from);
         return res;
+    }
+    static Y deserialize(const serialize::structure& data) {
+        uint64_t from = 0;
+        return deserialize(data, from);
     }
     friend bool operator==(const Y& a, const Y& b) {
         return a.i == b.i && a.s == b.s && std::equal(a.v.begin(), a.v.end(), b.v.begin(), b.v.end());

--- a/test/shared/test_serialize.cpp
+++ b/test/shared/test_serialize.cpp
@@ -130,10 +130,10 @@ TEST_CASE("numberic types") {
         testint.run(0l);
         testint.run(SIZE_MAX);
     }
-    SECTION("ssize_t") {
-        test<ssize_t> testint;
+    SECTION("long") {
+        test<long> testint;
         testint.run(0l);
-        testint.run(SSIZE_MAX);
+        testint.run(LONG_MAX);
         testint.run(LONG_MIN);
     }
 }


### PR DESCRIPTION
Old serialize was getting a bit messy. So I tried to redesign it, all numeric types, serializable objects and containers can be serialized just by calling serialize(object, result) (works for nested containers of any depth) and deserialized by calling desrialize<Obj>(input, starting offset) (object is constructed inside and returned is new object) .